### PR TITLE
Use tldts for domain parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ambire-dapps",
+  "version": "1.0.0",
+  "description": "",
+  "main": "fetchData.js",
+  "scripts": {
+    "test": "node test/dedupe.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "tldts": "^6.1.8"
+  }
+}

--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { deduplicateEntries } = require('../fetchData');
+
+const sampleData = [
+  { url: 'https://app.aave.com', name: 'Aave', category: 'Lending', logo: 'icon1' },
+  { url: 'https://mirror.aave.com', name: 'Aave Mirror', category: 'DeFi', logo: 'icon2' },
+  { url: 'https://app.uniswap.org', name: 'Uniswap', category: 'DEX', logo: 'icon3' }
+];
+
+const result = deduplicateEntries(sampleData);
+
+assert.strictEqual(result.length, 2, 'Entries should be deduplicated by domain');
+
+const aave = result.find(r => r.url.includes('aave.com'));
+assert.deepStrictEqual(aave.category.sort(), ['DeFi', 'Lending'].sort(), 'Categories should merge for same domain');
+
+const uniswap = result.find(r => r.url.includes('uniswap.org'));
+assert.strictEqual(uniswap.url, 'https://uniswap.org');
+
+console.log('All tests passed!');
+


### PR DESCRIPTION
## Summary
- add `tldts` dependency and minimal `package.json`
- swap custom domain parsing logic for `tldts`
- deduplicate entries using `tldts` output
- export `deduplicateEntries` and only run network fetch when executed directly
- add basic test for deduplication logic

## Testing
- `npm test` *(fails: Cannot find module 'tldts')*


------
https://chatgpt.com/codex/tasks/task_e_685bfc2f9640832f96cea3a1f694ccf0