### PR TITLE
Fix update workflow to install deps & run tests

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,17 @@ jobs:
       with:
         token: ${{ secrets.UPDATE }}
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test
+
     - name: Run Data Script
       run: node fetchData.js
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "fetchData.js",
   "scripts": {
-    "test": "node test/dedupe.test.js"
+    "test": "node ./test/dedupe.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- run npm ci & tests in update workflow
- tweak package.json test script

## Testing
- `npm test` *(fails: Cannot find module 'tldts')*

------
https://chatgpt.com/codex/tasks/task_e_685c0e627c50832fb37bec13d3c914f4