### PR TITLE
refactor: externalize filter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # ambire-dapps
+
+## Usage
+
+Install dependencies and run the data fetcher:
+
+```bash
+npm install
+node fetchData.js
+```
+
+## Configuration
+
+The filtering logic used by `fetchData.js` is stored in `config/filters.json`. Update this file instead of editing the script when you need to adjust filtering rules.
+
+The file accepts three arrays:
+
+- `notAllowedChains`: chains that should be ignored when evaluating protocol data. Protocols are discarded if they only appear on these chains.
+- `excludedCategories`: protocol categories that should never appear in the output.
+- `categoriesWithoutTVL`: categories that are allowed even when their reported TVL is missing or below the default threshold.
+
+After updating `config/filters.json`, rerun `node fetchData.js` to regenerate the output files with the new filters.

--- a/config/filters.json
+++ b/config/filters.json
@@ -1,0 +1,39 @@
+{
+  "notAllowedChains": [
+    "Bitcoin",
+    "Solana",
+    "Doge",
+    "Ripple",
+    "Tron",
+    "Polkadot",
+    "Near",
+    "Algorand",
+    "Aptos",
+    "Litecoin",
+    "Cosmos",
+    "EOS",
+    "TEZOS",
+    "Zilliqa",
+    "Cardano",
+    "Thorchain",
+    "IoTeX",
+    "NEO"
+  ],
+  "excludedCategories": [
+    "CEX",
+    "AI Agents",
+    "Yield Lottery",
+    "Decentralized Stablecoin",
+    "Anchor BTC",
+    "Algo-Stables",
+    "Governance Incentives",
+    "Privacy",
+    "Reserve Currency",
+    "SoFi",
+    "Staking Pool",
+    "Staking",
+    "Token Locker",
+    "Treasury Manager"
+  ],
+  "categoriesWithoutTVL": []
+}

--- a/fetchData.js
+++ b/fetchData.js
@@ -24,48 +24,32 @@ if (fs.existsSync(outputDir)) {
   fs.mkdirSync(outputDir);
 }
 
-// Chains to filter (not allowed chains)
-const notAllowedChains = [
-  "Bitcoin",
-  "Solana",
-  "Doge",
-  "Ripple",
-  "Tron",
-  "Polkadot",
-  "Near",
-  "Algorand",
-  "Aptos",
-  "Litecoin",
-  "Cosmos",
-  "EOS",
-  "TEZOS",
-  "Zilliqa",
-  "Cardano",
-  "Thorchain",
-  "IoTeX",
-  "NEO"
-];
+// Load filtering configuration
+const filtersConfigPath = path.join(__dirname, 'config', 'filters.json');
+let filtersConfig = {
+  notAllowedChains: [],
+  excludedCategories: [],
+  categoriesWithoutTVL: []
+};
 
-// Categories to exclude
-const excludedCategories = [
-  "CEX",
-  "AI Agents",
-  "Yield Lottery",
-  "Decentralized Stablecoin",
-  "Anchor BTC",
-  "Algo-Stables",
-  "Governance Incentives",
-  "Privacy",
-  "Reserve Currency",
-  "SoFi",
-  "Staking Pool",
-  "Staking",
-  "Token Locker",
-  "Treasury Manager"
-];
+try {
+  const rawConfig = fs.readFileSync(filtersConfigPath, 'utf-8');
+  const parsedConfig = JSON.parse(rawConfig);
+  filtersConfig = {
+    ...filtersConfig,
+    ...parsedConfig
+  };
+} catch (err) {
+  console.warn(
+    `Could not read filters configuration at ${filtersConfigPath}. Using defaults. ${err.message}`
+  );
+}
 
-const categoriesWithoutTVL = [
-]
+const {
+  notAllowedChains,
+  excludedCategories,
+  categoriesWithoutTVL
+} = filtersConfig;
 
 // Read from input.json if it exists
 let manualEntries = [];


### PR DESCRIPTION
## Summary
- move chain/category filtering lists into a shared config/filters.json file
- load the filters from disk in fetchData.js and provide defaults if the file is missing
- document how to edit the filter configuration without touching the script

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c9682ec0dc832f9a00cac33efcf330